### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/hueserviceadvanced/manifest.json
+++ b/custom_components/hueserviceadvanced/manifest.json
@@ -2,6 +2,7 @@
   "domain": "hueserviceadvanced",
   "name": "Hue Service Advanced",
   "config_flow": true,
+  "version": "1.3.5",
   "documentation": "https://www.home-assistant.io/integrations/hue",
   "ssdp": [],
   "homekit": {},


### PR DESCRIPTION
Version number is now mandatory, as specified in https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions